### PR TITLE
Remove deprecated Mapbox Distance API in favor of Matrix API.

### DIFF
--- a/ios/lightrail.xcodeproj/project.pbxproj
+++ b/ios/lightrail.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 				00E356EF1AD99517003FC87E /* lightrailTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				AA79B03A1DCECF5B0072B941 /* Frameworks */,
+				AA79D77B2008171800F0EB5B /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -485,6 +486,14 @@
 				AA79B03B1DCECF5B0072B941 /* RNQuickActionManager.h */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		AA79D77B2008171800F0EB5B /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				71E0A5395CED4D10991BE9E5 /* libRCTMapboxGL.a */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/ios/lightrail.xcodeproj/xcshareddata/xcschemes/lightrail.xcscheme
+++ b/ios/lightrail.xcodeproj/xcshareddata/xcschemes/lightrail.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -69,6 +70,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/src/helpers/mapboxDistanceAPI.js
+++ b/src/helpers/mapboxDistanceAPI.js
@@ -8,7 +8,7 @@ export const mapboxDistanceAPI = {
     const endpoint = `directions-matrix/v1/mapbox/${mode}`;
     const coordinatesString = coordinates.map(coordinate => coordinate.toString());
     const coordinatesQuery = coordinatesString.join(';');
-    const url = `https://api.mapbox.com/${endpoint}/${coordinatesQuery}?access_token=${mapboxApiKey}`;
+    const url = `https://api.mapbox.com/${endpoint}/${coordinatesQuery}?sources=0&access_token=${mapboxApiKey}`;
     return fetch(url).then(res => res.json());
   }
 };

--- a/src/helpers/mapboxDistanceAPI.js
+++ b/src/helpers/mapboxDistanceAPI.js
@@ -5,24 +5,10 @@ export const mapboxDistanceAPI = {
     const coordinates = destinations;
     coordinates.unshift(origin);
 
-    if (__DEV__) {
-      const endpoint = `directions-matrix/v1/mapbox/${mode}`;
-      const coordinatesString = coordinates.map(coordinate => coordinate.toString());
-      const coordinatesQuery = coordinatesString.join(';');
-      const url = `https://api.mapbox.com/${endpoint}/${coordinatesQuery}?access_token=${mapboxApiKey}`;
-      return fetch(url).then(res => res.json());
-    }
-
-    const endpoint = `distances/v1/mapbox/${mode}`;
-    const url = `https://api.mapbox.com/${endpoint}?access_token=${mapboxApiKey}`;
-    return fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        coordinates
-      })
-    }).then(res => res.json());
+    const endpoint = `directions-matrix/v1/mapbox/${mode}`;
+    const coordinatesString = coordinates.map(coordinate => coordinate.toString());
+    const coordinatesQuery = coordinatesString.join(';');
+    const url = `https://api.mapbox.com/${endpoint}/${coordinatesQuery}?access_token=${mapboxApiKey}`;
+    return fetch(url).then(res => res.json());
   }
 };


### PR DESCRIPTION
Mapbox is turning off their deprecated Distance API on January 15, 2018. To ensure the application continues working, we must use their Matrix API instead.

This may prove problematic. The Matrix API's free tier includes 50,000 API calls per month. Each nearest-station query uses up 16 of these calls. (It was 16 x 16 before I optimized it to include the user's location as the only source!) Still, this allows for only around 104 nearest-station queries per day, across all our users. This will likely not be enough.

Additional API calls cost $0.50 per 1,000. That could add up quickly. I don't currently have a payment method on file with Mapbox, so when we near our limit, we'll get a warning. When we exceed it, we'll get a 10-day grace period before they shut us off.

As for alternatives, the Google Distance Matrix API has a monthly free-tier cap of 75,000 API calls. That's a modest increase, but it's not a viable solution at all; their T&C forbid it being used when displaying another map provider's map.

So, we may need to entertain various options, including, but not limited to:

- Programmatically find the 3 or 4 nearest stations as-the-crow-flies, and only include those in our Mapbox Distance Matrix API request. (This is probably the best option.)
- Find another distance matrix API
- Pay for any additional overage out-of-pocket
- If overage is modest, collect donations?
- Charge for the application?
- Reach out to developers in the community that might want to help? For example, we could link to their apps from ours (I'm thinking maybe apps that are providing ticketing services?)

We may have to get creative.