### PR TITLE
Fix bug crashing app on schedule screen in Release mode

### DIFF
--- a/src/scenes/ScheduleInfo/ScheduleInfo.js
+++ b/src/scenes/ScheduleInfo/ScheduleInfo.js
@@ -103,12 +103,12 @@ export default class ScheduleInfo extends React.Component {
   getSchedule = () => {
     const days = this.state.scheduleValue;
     return (
-      <TableColScrollView innerRef={(c) => { this.scheduleScrollView = c; }}>
+      <TableColScrollView innerRef={(c) => { this.scheduleScrollView = c && c.ref; }}>
         <TableView>
-          <TableColInboundView innerRef={(c) => { this.inboundWrapper = c; }}>
+          <TableColInboundView innerRef={(c) => { this.inboundWrapper = c && c.ref; }}>
             {this.getTrainTimes('inbound', days)}
           </TableColInboundView>
-          <TableColOutboundView innerRef={(c) => { this.outboundWrapper = c; }} onLayout={this.setScheduleAlignment}>
+          <TableColOutboundView innerRef={(c) => { this.outboundWrapper = c && c.ref; }} onLayout={this.setScheduleAlignment}>
             {this.getTrainTimes('outbound', days)}
           </TableColOutboundView>
         </TableView>
@@ -118,7 +118,9 @@ export default class ScheduleInfo extends React.Component {
 
   // We call this when we want to scroll down programmatically
   performScroll = (y, animated) => {
-    this.scheduleScrollView.scrollTo({ x: 0, y, animated });
+    if (this.scheduleScrollView) {
+      this.scheduleScrollView.scrollTo({ x: 0, y, animated });
+    }
   }
 
   scheduleValueHandler = (value) => {

--- a/src/scenes/ScheduleInfo/ScheduleInfoCss.js
+++ b/src/scenes/ScheduleInfo/ScheduleInfoCss.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { ScrollView, View } from 'react-native';
 import styled from 'styled-components/native';
 import { deviceProps } from 'helpers/device';
 
@@ -82,7 +84,22 @@ export const DescriptionText = styled.Text`
   color: ${props => props.theme.primaryTextColor};
 `;
 
-export const TableColScrollView = styled.ScrollView`
+// Fix to make underlying native component ref available (instead of the unstyled component itself)
+// Without this, innerRef was returning undefined in Release/Production mode.
+// See: https://github.com/styled-components/styled-components/issues/618
+class TableColScrollViewComponent extends React.Component {
+  render() {
+    return <ScrollView ref={(view) => { this.ref = view; }} {...this.props} />;
+  }
+}
+
+class TableColViewComponent extends React.Component { // eslint-disable-line
+  render() {
+    return <View ref={(view) => { this.ref = view; }} {...this.props} />;
+  }
+}
+
+export const TableColScrollView = styled(TableColScrollViewComponent)`
   backgroundColor: ${props => props.theme.backgroundColor};
 `;
 
@@ -92,7 +109,7 @@ export const TableView = styled.View`
   paddingBottom: 10px;
 `;
 
-const TableColView = styled.View`
+const TableColView = styled(TableColViewComponent)`
   flex: 1;
   alignSelf: flex-start;
 `;


### PR DESCRIPTION
In Production/Release mode, the refactored app (development branch) crashes when opening the schedule scene. The cause? Apparently the `innerRef` prop provided by `styled-components` doesn't give you the actual ref to the native element, but rather the component...or something like that. That means that when trying to call things like `ref.setNativeProps()` it would fail because `ref` is `undefined`.

To fix this, I followed the instructions here: https://github.com/styled-components/styled-components/issues/618

And added some more protections to fix other crashes happening (like looking for the `ref` when its component has already unmounted, etc.)