### PR TITLE
Mapbox optimization

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "no-alert": 0,
     "no-debugger": 2,
     "no-return-assign": [1, "always"],
+    "no-plusplus": 0,
     "max-len": [1, {
       "code": 150,
       "tabWidth": 2

--- a/ios/lightrail/Info.plist
+++ b/ios/lightrail/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>6</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>comgooglemaps</string>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node": "^6.9.2"
   },
   "dependencies": {
+    "geolib": "^2.0.24",
     "moment": "2.15.2",
     "prop-types": "15.5.10",
     "react": "15.3.2",

--- a/src/components/StationCard/StationCard.js
+++ b/src/components/StationCard/StationCard.js
@@ -33,7 +33,7 @@ export default class StationCard extends React.Component {
 
   renderDistanceText = () => {
     const { stationIndex, stationDistances, mode } = this.props;
-    if (stationDistances) {
+    if (stationDistances && stationDistances[stationIndex].duration) {
       return `${stationDistances[stationIndex].durationText} ${mode === 'driving' ? 'drive' : 'walk'}`;
     }
     return null;

--- a/src/helpers/mapboxDistanceAPI.js
+++ b/src/helpers/mapboxDistanceAPI.js
@@ -1,14 +1,48 @@
+import geolib from 'geolib';
 import { mapboxApiKey } from './config';
+
+
+const orderByDistance = (origin, destinations) => {
+  const currentLocation = { latitude: origin[1], longitude: origin[0] };
+  const stations = destinations.map(latlng => ({ latitude: latlng[1], longitude: latlng[0] }));
+
+  const nearestStationDistances = geolib
+    .orderByDistance(currentLocation, stations)
+    .slice(0, 3)
+    .sort((a, b) => a.key - b.key);
+
+  const nearestStationCoordinates = nearestStationDistances.map(item => destinations[item.key]);
+  const nearestStationIndices = nearestStationDistances.map(item => item.key);
+
+  return { coordinates: nearestStationCoordinates, indices: nearestStationIndices };
+};
 
 export const mapboxDistanceAPI = {
   getDistance(origin, destinations, mode) {
-    const coordinates = destinations;
-    coordinates.unshift(origin);
+    // First, get the nearest three stations as-the-crow-flies, to save on API calls.
+    const { coordinates, indices } = orderByDistance(origin, destinations);
 
+    // Prepare the URL for the GET request.
+    coordinates.unshift(origin);
     const endpoint = `directions-matrix/v1/mapbox/${mode}`;
     const coordinatesString = coordinates.map(coordinate => coordinate.toString());
     const coordinatesQuery = coordinatesString.join(';');
     const url = `https://api.mapbox.com/${endpoint}/${coordinatesQuery}?sources=0&access_token=${mapboxApiKey}`;
-    return fetch(url).then(res => res.json());
+
+    // Fetch the datat from the Mapbox API.
+    return fetch(url)
+      .then(res => res.json())
+      .then(res => res.durations[0].slice(1)) // remove our current location from the results
+      .then((res) => { // build out an array representing the station distances, with null values for stations that were not queried
+        const distances = [];
+        for (let i = 0; i < destinations.length; i++) {
+          if (indices.includes(i.toString())) {
+            distances.push(res.shift());
+          } else {
+            distances.push(null);
+          }
+        }
+        return distances;
+      });
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,6 +2334,10 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
+geolib@^2.0.24:
+  version "2.0.24"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-2.0.24.tgz#eb3d7fbc65f5ea3354a5af6054563ebe9f33e5f4"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"


### PR DESCRIPTION
Related to Issue #4 

Mapbox is already costing too much. To decrease API usage five-fold, I'm pulling in geolib, finding the three nearest stations as the crow flies, and querying those via the Mapbox API. Hopefully this well keep us in the free tier starting next month. We may have to revisit it as more users come on board with the lightrail extension.